### PR TITLE
Add minimal IPFS asset builder

### DIFF
--- a/lib/ipfs_asset_builder.dart
+++ b/lib/ipfs_asset_builder.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:yaml/yaml.dart';
+
+/// A minimal [Builder] that reads the `pubspec.yaml` file.
+///
+/// This currently only parses the pubspec and logs that it was loaded. In the
+/// future it will emit a manifest describing package assets available via IPFS.
+class IpfsAssetBuilder implements Builder {
+  @override
+  final Map<String, List<String>> buildExtensions = const {
+    r'$package$': ['ipfs_asset_manifest.json']
+  };
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    final pubspecId = AssetId(buildStep.inputId.package, 'pubspec.yaml');
+    final pubspecContent = await buildStep.readAsString(pubspecId);
+    // Parse the YAML just to verify it is valid. The resulting map is unused for
+    // now but will be used when generating the manifest later.
+    loadYaml(pubspecContent);
+
+    log.info('Loaded pubspec for package ${buildStep.inputId.package}');
+  }
+}
+
+/// Factory used by `build_runner` to create the builder.
+Builder ipfsAssetBuilder(BuilderOptions options) => IpfsAssetBuilder();
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   http: ^1.2.1
   path_provider: ^2.1.3
   crypto: ^3.0.3
+  yaml: ^3.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a minimal build system utility that reads pubspec
- include `yaml` as a dependency

## Testing
- `flutter pub get`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_684e9bfac8008321bcb230d7b742189b